### PR TITLE
fixed navbar to redirect to post/ not log user out

### DIFF
--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -6,8 +6,8 @@ const PostsController = {
       if (err) {
         throw err;
       }
-
-      res.render("posts/index", { posts: posts });
+        // Implemented authentication logic to dynamically update navbar links based on the user's login status.
+      res.render("posts/index", { posts: posts, isAuthenticated: true});
     });
   },
   New: (req, res) => {

--- a/controllers/sessions.js
+++ b/controllers/sessions.js
@@ -20,9 +20,7 @@ const SessionsController = {
         res.redirect("/sessions/login");
       } else {
         req.session.user = user;
-        // Implemented authentication logic to dynamically update navbar links based on the user's login status.
-        const isAuthenticated = req.session.user ? true : false;
-        res.render("posts", { isAuthenticated: isAuthenticated });
+        res.redirect("/posts");
       }
     });
   },


### PR DESCRIPTION
Updates to our navbar for when a user logs in, they will be automatically redirected to the "/posts" page instead of the "sessions" page. Additionally, we have resolved the issue that was causing users to get logged out when they clicked the "Posts" link on the navbar.